### PR TITLE
fix(interface): adding back heading alignment

### DIFF
--- a/src/interface/tools/text-align/index.ts
+++ b/src/interface/tools/text-align/index.ts
@@ -13,9 +13,18 @@ export default defineTool({
     extension: [
         (selection) =>
             TextAlign.configure({
-                types: selection?.filter((extension) =>
-                    ["heading", "paragraph", "codeBlock"].includes(extension)
-                ),
+                types: [
+                    ...(
+                        selection?.filter((extension) => 
+                            ["h1", "h2", "h3", "h4", "h5", "h6"].includes(extension)
+                        ).length ?
+                        ['heading'] :
+                        []
+                    ),
+                    ...selection?.filter((extension) =>
+                       ["paragraph", "codeBlock"].includes(extension)
+                    )
+                  ],
             }),
     ],
     toolbarButton: ToolButton,


### PR DESCRIPTION
Code from the ticket https://github.com/formfcw/directus-extension-flexible-editor/issues/60

### To be checked
- indentation
- update version number in package-lock.json

### Tests
- Add a flexible editor field inside a collection
- Add a paragraph, heading 1, heading 2, ...
- Update the text-align with center/right for paragraph, h1, h2