### PR TITLE
fix(interface): guard against undefined relationNodesValues blanking the Interface tab

### DIFF
--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -304,7 +304,7 @@ export default defineInterface({
                     (item: any) => item.meta?.one_allowed_collections?.length
                 )?.meta?.one_allowed_collections;
 
-                if (!relationNodesValues.length) return;
+                if (!relationNodesValues?.length) return;
 
                 const collectionsStore = useCollectionsStore();
                 collectionsStore.collection;


### PR DESCRIPTION
### The bug

In `src/interface/index.ts`, `options()` → `useRelationReferenceOptions()` → `getRelatedAnyCollections()`:

```ts
const relationNodesValues = m2aRelations.find(
    (item: any) => item.meta?.one_allowed_collections?.length
)?.meta?.one_allowed_collections;

if (!relationNodesValues.length) return;   // ← TypeError
```

`.find()` returns `undefined` when no relation on the m2a field has a non-empty `one_allowed_collections`, and the next line dereferences `.length` on it.

### Why it's worse than it looks

The `TypeError` propagates out of the interface's `options()` function, so the App cannot build the options form at all. The result is not a missing option — the **entire Interface tab of the field detail drawer renders blank**: no interface picker, no options, nothing. There's no in-UI way to fix the field's configuration once it's in this state.

### Reproduction

A field whose `meta.options.m2aField` points at an m2a alias whose relation has `one_allowed_collections = null` — i.e. an m2a relation created before its allowed collections were configured. We hit this on an instance where all 19 `editor_nodes` relations were in that state; it stayed dormant until something started writing `m2aField` onto fields, since the crash needs `m2aField` set *and* the allowed-collections list empty.

### The fix

Optional-chain the guard. This matches every other "not configured" branch in the same function (`if (!m2aField) return`, `if (!m2aRelations.length) return`, `if (!relationNodesOptions.length) return`): return early and simply omit the relation-node options, leaving the rest of the options form intact.

One line, no behaviour change for correctly configured fields.
